### PR TITLE
Rename ethercat start into ethercat reinitialize

### DIFF
--- a/atrio/trio.py
+++ b/atrio/trio.py
@@ -379,8 +379,11 @@ class Trio:
     def ethercat_set_state(self, state : EthercatState):
         return self.commandS(f"ETHERCAT($21, 0, {state.value}, 0) ")
 
-    def ethercat_start(self):
+    def ethercat_reinitialize(self):
         return self.commandS("ETHERCAT(0, 0)")
+
+    def ethercat_start(self):
+        return self.ethercat_state(EthercatState.Operational)
 
     def ethercat_stop(self):
         return self.commandS("ETHERCAT(1, 0)")

--- a/atrio/trio_cmd.py
+++ b/atrio/trio_cmd.py
@@ -114,7 +114,7 @@ def main():
 
     ethercat_parser = subparsers.add_parser('ethercat', help="trio ethercat commands")
     ethercat_subparsers = ethercat_parser.add_subparsers()
-    for f in ["list", "state", "start", "stop"]:
+    for f in ["list", "state", "reinitialize", "start", "stop"]:
         sp = ethercat_subparsers.add_parser(f)
         sp.set_defaults(subfunc=f)
         sp.set_defaults(func=controller_ethercat)


### PR DESCRIPTION
The call `ethercat(0,0)` reinitialize the ethercat master. So calling it `start` is a bit confusing.