### PR TITLE
Restart and autorun fixes + bringing basic hardware in the loop tests

### DIFF
--- a/atrio/trio.py
+++ b/atrio/trio.py
@@ -238,6 +238,7 @@ class Trio:
                 try:
                     self.connect(timeout=1)
                     print("Restarted")
+                    print(self.commandS("AUTORUN"))
                     break
                 except:
                     print('.', end='', flush=True)

--- a/atrio/trio.py
+++ b/atrio/trio.py
@@ -208,7 +208,7 @@ class Trio:
         if r.group(1):
             self.print_extra_output(r.group(1))
 
-        err = re.match(b'.*%(\[[^\n]+)\r', r.group(2), re.MULTILINE | re.DOTALL)
+        err = re.match(b'.*%(\[COMMAND[^\n]+)\r', r.group(2), re.MULTILINE | re.DOTALL)
         if err:
             raise AtrioError("Command Error {}".format(err.group(1)))
         if r.group(3) != b'0x10000000A':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+argparse~=1.4.0
+argcomplete~=1.11.1
+crcmod~=1.7
+pytest~=5.4.1
+PyYAML~=5.3.1
+setuptools~=46.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-argparse~=1.4.0
-argcomplete~=1.11.1
-crcmod~=1.7
-pytest~=5.4.1
-PyYAML~=5.3.1
-setuptools~=46.1.3

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,12 @@ setuptools.setup(
     url="https://github.com/AbundantRobotics/atrio",
     packages=setuptools.find_packages(),
     install_requires=[
-        "argcomplete",
-        "pyyaml",
-        "crcmod",
+        "argparse~=1.4.0",
+        "argcomplete~=1.11.1",
+        "crcmod~=1.7",
+        "pytest~=5.4.1",
+        "PyYAML~=5.3.1",
+        "setuptools~=46.1.3",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""
+We provide the `trio` fixture which needs to connect to an hardware
+trio controller. To run the tests with hardware, you need to provide the ip
+of the trio with `--trio-ip` like:
+
+    pytest --trio-ip 192.168.0.1
+
+Not providing the ip will skip the tests using the trio fixture.
+"""
+
+import pytest
+
+""" Setup similar to the runslow example of pytest """
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--trio-ip", default="", help="If an IP is provided, test needing hardware will be run using it."
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "hw: mark test as needing hardware (a trio ip)")
+
+
+def pytest_collection_modifyitems(config, items):
+    ip = config.getoption("--trio-ip", None)
+    if ip:
+        print("Running HW tests on " + ip)
+        return
+    skip_hw = pytest.mark.skip(reason="need hardware to run (use --trio-ip option)")
+    for item in items:
+        if 'trio' in item.fixturenames:
+            item.add_marker(skip_hw)
+
+
+import atrio
+
+@pytest.fixture
+def trio(pytestconfig):
+    ip = pytestconfig.getoption("--trio-ip", None)
+    assert ip
+    with atrio.Trio(ip) as t:
+        yield t
+
+
+

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -1,0 +1,37 @@
+import atrio
+
+
+def test_version(trio):
+    assert trio.commandF("?version") >= 2.0297
+
+
+def test_manual_autorun(trio):
+    """
+    Command like `autorun` return some special output looking like usual errors.
+    Testing create a file, set it as autorun, call autorun, delete it.
+    """
+    rnds = "TMP_ATIYVANSERIJFH"
+    prgtype = atrio.program_types[".BAS"]
+    trio.write_program(rnds, prgtype, [f'BASE(0)'])
+    trio.autorun_program(rnds, prgtype, -1)
+    assert f"Program {rnds}] - Running" in trio.commandS("AUTORUN")
+    trio.delete_program(rnds)
+
+
+def test_restart_autorun_trigger(trio):
+    """
+    Command like `autorun` return some special output looking like usual errors.
+    Testing create a file, set it as autorun, call autorun, delete it.
+    """
+    rnds = "TMP_HGASUEOVJXKK"
+    prgtype = atrio.program_types[".BAS"]
+    trio.command("VR(42) = 40")
+    trio.write_program(rnds, prgtype, [f'VR(42) = 42'])
+    trio.autorun_program(rnds, prgtype, -1)
+
+    assert trio.commandF("?VR(42)") == 40
+    trio.restart()
+    assert trio.commandF("?VR(42)") == 42
+
+    trio.delete_program(rnds)
+

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ python =
     
 [testenv]
 deps=pytest
-commands=pytest
+commands=pytest {posargs}


### PR DESCRIPTION
Fixes:
- Some commands return "[PROCESS ...]" in case of success like `autorun`
- Restarting trio with EX doesn't autorun programs as documented..

Hardware in the loop tests are done using pytest and the custom `trio` fixture.
- To run the tests directly from the source directory: `python -m pytest . --trio-ip 10.0.0.100`
- To run the tests using tox (using installed version in virtualenvs): `tox -- --trio-ip 10.0.0.100`

Note that test with trio in the loop are slow....
