### PR TITLE
PROJECT_DATA file handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDE projects
+.idea/

--- a/atrio/trio.py
+++ b/atrio/trio.py
@@ -13,12 +13,12 @@ class AtrioError(Exception):
 
 
 program_types = {
-    ".BAS": 0,
-    ".TXT": 3,
-    ".MCC": 9,
-    ".BAL": 12,
+    ".BAS": 0,  # Program type
+    ".TXT": 3,  # Text type
+    ".MCC": 9,  # MC_CONFIG
+    ".BAL": 12,  # Basic library
+    ".PROJ": 7,  # Project type
 }
-
 
 def extension_from_prog_type(prog_type):
     """ Returns file extension from a trio prog_type """
@@ -29,7 +29,8 @@ code_types = {
     "Normal": ".BAS",
     "BASIC Lib": ".BAL",
     "Text": ".TXT",
-    "MC_CONFIG": ".MCC"
+    "MC_CONFIG": ".MCC",
+    "Project": ".PROJ"
 }
 
 
@@ -262,7 +263,11 @@ class Trio:
     def read_program(self, progname):
         return self.commandS("LIST \"{}\"".format(progname))
 
-    def write_program(self, progname, prog_type, lines):
+    def write_program(self, progname, prog_type=None, lines=None):
+        if prog_type is None:
+            prog_type = program_types['.BAS']
+        if not lines:
+            lines = ['']
         try:
             self.delete_program(progname)
             self.command("SELECT {},{}".format(self.quote(progname), prog_type))
@@ -274,7 +279,7 @@ class Trio:
             for _ in range(60):
                 if self.commandI("?FLASH_STATUS"):
                     self.command("!{},Z".format(progname))
-                    time.sleep(0.1)
+                    time.sleep(0.03)
                 else:
                     break
             else:
@@ -344,10 +349,8 @@ class Trio:
     def checksum_program(self, progname):
         return self.commandI("EDPROG{},10".format(self.quote(progname)))
 
-    def autorun_program(self, progname, prog_type, process):
+    def autorun_program(self, progname, process):
         """ Process -1 is automatic process selection, None removes the autorun"""
-        if prog_type != 0:
-            raise AtrioError(f"Cannot set autorun on non program {progname}")
         prog = self.quote(progname)
         autorun = process is not None
         if autorun:

--- a/atrio/trio.py
+++ b/atrio/trio.py
@@ -59,8 +59,10 @@ progtable_regex = \
     )
 
 
-def prettyprint_progtable(list_files):
+def prettyprint_progtable(list_files, all=False):
     for k in list_files.values():
+        if k['codetype'] == "Project" and not all:
+            continue
         autorun = k.get('autorun', None)
         if autorun:
             autorunstr = " ({})".format(autorun)

--- a/atrio/trio_cmd.py
+++ b/atrio/trio_cmd.py
@@ -25,7 +25,7 @@ def controller_cmd(args):
 
 def controller_ls(args):
     t = construct_trio(args)
-    return atrio.prettyprint_progtable(t.list_files())
+    return atrio.prettyprint_progtable(t.list_files(), args.lsall)
 
 def controller_top(args):
     t = construct_trio(args)
@@ -108,6 +108,7 @@ def main():
 
     ls_parser = subparsers.add_parser('ls', help="List files in the controller")
     ls_parser.set_defaults(func=controller_ls)
+    ls_parser.add_argument('--lsall', '-a', action='store_true', help="Display all files including projetc files")
 
     top_parser = subparsers.add_parser('top', help="List process and cpu usage in the controller")
     top_parser.set_defaults(func=controller_top)

--- a/atrio/workspace.py
+++ b/atrio/workspace.py
@@ -160,7 +160,9 @@ class Workspace:
                     update_autorun = True
 
             if update_autorun or filename in cdiff["autorun_changed"]:
-                self.trio.autorun_program(progname, prog_type, autorun)
+                if prog_type != 0:
+                    raise AtrioError(f"Cannot set autorun on non BAS program {progname}")
+                self.trio.autorun_program(progname, autorun)
                 if autorun:
                     print(f"Restart needed to autorun {filename}")
                     restart_needed = True

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "argcomplete~=1.11",
         "crcmod~=1.7",
         "pytest~=5.4",
-        "PyYAML~=5.3",
+        "PyYAML>=3",
         "setuptools~=46.1",
     ],
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,15 @@ of the trio with `--trio-ip` like:
     pytest --trio-ip 192.168.0.1
 
 Not providing the ip will skip the tests using the trio fixture.
+
+Some tests are quite slow and are marked as such with `pytest.mark.slow`. To not run them:
+
+    pytest --trio-ip 192.168.0.1 -m "not slow"
+
+To run only them:
+
+    pytest --trio-ip 192.168.0.1 -m "slow"
+
 """
 
 import pytest
@@ -15,23 +24,23 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--trio-ip", default="", help="If an IP is provided, test needing hardware will be run using it."
+        "--trio-ip", default="", help="If an IP is provided, test needing hardware will be run using it"
     )
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "hw: mark test as needing hardware (a trio ip)")
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
 
 
 def pytest_collection_modifyitems(config, items):
     ip = config.getoption("--trio-ip", None)
     if ip:
         print("Running HW tests on " + ip)
-        return
-    skip_hw = pytest.mark.skip(reason="need hardware to run (use --trio-ip option)")
-    for item in items:
-        if 'trio' in item.fixturenames:
-            item.add_marker(skip_hw)
+    else:
+        skip_hw = pytest.mark.skip(reason="need hardware to run (use --trio-ip option)")
+        for item in items:
+            if 'trio' in item.fixturenames:
+                item.add_marker(skip_hw)
 
 
 import atrio
@@ -42,6 +51,23 @@ def trio(pytestconfig):
     assert ip
     with atrio.Trio(ip) as t:
         yield t
+
+
+import random
+import string
+
+@pytest.fixture
+def trio_tmp_prog(trio, request):
+    tmp_prog_lines = request.node.get_closest_marker("tmp_prog_lines")
+    if tmp_prog_lines:
+        tmp_prog_lines = tmp_prog_lines.args[0]
+    else:
+        tmp_prog_lines = ['']
+
+    name = "TMP_" + ''.join(random.choices(string.ascii_uppercase, k=8))
+    trio.write_program(name, lines=tmp_prog_lines)
+    yield name
+    trio.delete_program(name)
 
 
 

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -1,37 +1,42 @@
 import atrio
+import pytest
 
 
 def test_version(trio):
+    """ We have not tested with older firmware versions """
     assert trio.commandF("?version") >= 2.0297
 
 
-def test_manual_autorun(trio):
+@pytest.mark.tmp_prog_lines(['BASE(0)'])
+def test_manual_autorun(trio, trio_tmp_prog):
+    """
+    Command like `autorun` return some special output looking like usual errors.
+    """
+    trio.autorun_program(trio_tmp_prog, -1)
+    assert f"Program {trio_tmp_prog}] - Running" in trio.commandS("AUTORUN")
+
+
+def test_list_files(trio, trio_tmp_prog):
+    trio.autorun_program(trio_tmp_prog, 10)
+    ls = trio.list_files()
+    assert trio_tmp_prog in ls
+    assert ls[trio_tmp_prog]['progname'] == trio_tmp_prog
+    assert ls[trio_tmp_prog]['code'] == '0'  # empty program
+    assert ls[trio_tmp_prog]['autorun'] == '10'
+    assert atrio.code_types[ls[trio_tmp_prog]['codetype']] == '.BAS'
+
+
+@pytest.mark.slow
+@pytest.mark.tmp_prog_lines(['VR(42) = 42'])
+def test_restart_autorun_trigger(trio, trio_tmp_prog):
     """
     Command like `autorun` return some special output looking like usual errors.
     Testing create a file, set it as autorun, call autorun, delete it.
     """
-    rnds = "TMP_ATIYVANSERIJFH"
-    prgtype = atrio.program_types[".BAS"]
-    trio.write_program(rnds, prgtype, [f'BASE(0)'])
-    trio.autorun_program(rnds, prgtype, -1)
-    assert f"Program {rnds}] - Running" in trio.commandS("AUTORUN")
-    trio.delete_program(rnds)
+    trio.autorun_program(trio_tmp_prog, -1)
 
-
-def test_restart_autorun_trigger(trio):
-    """
-    Command like `autorun` return some special output looking like usual errors.
-    Testing create a file, set it as autorun, call autorun, delete it.
-    """
-    rnds = "TMP_HGASUEOVJXKK"
-    prgtype = atrio.program_types[".BAS"]
     trio.command("VR(42) = 40")
-    trio.write_program(rnds, prgtype, [f'VR(42) = 42'])
-    trio.autorun_program(rnds, prgtype, -1)
-
     assert trio.commandF("?VR(42)") == 40
     trio.restart()
     assert trio.commandF("?VR(42)") == 42
-
-    trio.delete_program(rnds)
 


### PR DESCRIPTION
Newer firmwares like the 2.305 generate a `PROJECT_DATA` file of type "Project" that was not supported yet. `atrio ls` will not list it anymore while `atrio ls -a` will.

Testing fixtures have been updated to easy writing tests needing temporary trio programs.